### PR TITLE
Add control of title to markdown command

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,10 @@ steps:
   # Create a summary markdown from the specified SPDX document
 - command: to-markdown
   inputs:
-    spdx: input.spdx.json
-    markdown: output.md
+    spdx: <spdx.json>             # SPDX file name
+    markdown: <out.md>            # Output markdown file
+    title: <title>                # Optional title
+    depth: <depth>                # Optional heading depth
 
   # Update a package in an SPDX document
 - command: update-package

--- a/spdx-workflow.yaml
+++ b/spdx-workflow.yaml
@@ -56,3 +56,4 @@ steps:
   inputs:
     spdx: ${{ spdx }}
     markdown: ${{ summary-markdown }}
+    title: 'SpdxTool Package'


### PR DESCRIPTION
This PR implements #17 by adding title and depth control over the to-markdown command.