### PR TITLE
Improve summary

### DIFF
--- a/src/DemaConsulting.SpdxTool/Commands/ToMarkdown.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/ToMarkdown.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using DemaConsulting.SpdxModel;
 using DemaConsulting.SpdxTool.Spdx;
 using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
@@ -131,19 +132,48 @@ public class ToMarkdown : Command
         markdown.AppendLine($"| Created | {doc.CreationInformation.Created} |");
         foreach (var creator in doc.CreationInformation.Creators)
             markdown.AppendLine($"| Creator | {creator} |");
+        foreach (var package in doc.GetRootPackages())
+            markdown.AppendLine($"| Root Package | {package.Name} |");
         markdown.AppendLine();
         markdown.AppendLine();
 
+        // Find tool package IDs
+        var toolIds = new HashSet<string>();
+        foreach (var relationship in doc.Relationships)
+            if (relationship.RelationshipType is SpdxRelationshipType.BuildToolOf or SpdxRelationshipType.DevToolOf or SpdxRelationshipType.TestToolOf)
+                toolIds.Add(relationship.Id);
+
+        // Find the tools and packages
+        var tools = doc.Packages.Where(p => toolIds.Contains(p.Id)).OrderBy(p => p.Name).ToArray();
+        var packages = doc.Packages.Except(tools).OrderBy(p => p.Name).ToArray();
+
         // Print the packages
-        markdown.AppendLine($"{header}# Package Summary");
-        markdown.AppendLine();
-        markdown.AppendLine("| Name | Version | License |");
-        markdown.AppendLine("| :-------- | :--- | :--- |");
-        foreach (var package in doc.Packages.OrderBy(p => p.Name))
-            markdown.AppendLine(
-                $"| {package.Name} | {package.Version ?? string.Empty} | {package.ConcludedLicense} |");
-        markdown.AppendLine();
-        markdown.AppendLine();
+        if (packages.Length > 0)
+        {
+            markdown.AppendLine($"{header}# Package Summary");
+            markdown.AppendLine();
+            markdown.AppendLine("| Name | Version | License |");
+            markdown.AppendLine("| :-------- | :--- | :--- |");
+            foreach (var package in packages)
+                markdown.AppendLine(
+                    $"| {package.Name} | {package.Version ?? string.Empty} | {package.ConcludedLicense} |");
+            markdown.AppendLine();
+            markdown.AppendLine();
+        }
+
+        // Print the tools
+        if (tools.Length > 0)
+        {
+            markdown.AppendLine($"{header}# Tool Summary");
+            markdown.AppendLine();
+            markdown.AppendLine("| Name | Version | License |");
+            markdown.AppendLine("| :-------- | :--- | :--- |");
+            foreach (var package in tools)
+                markdown.AppendLine(
+                    $"| {package.Name} | {package.Version ?? string.Empty} | {package.ConcludedLicense} |");
+            markdown.AppendLine();
+            markdown.AppendLine();
+        }
 
         // Save the Markdown text to file
         File.WriteAllText(markdownFile, markdown.ToString());

--- a/test/DemaConsulting.SpdxTool.Tests/TestToMarkdown.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestToMarkdown.cs
@@ -42,14 +42,32 @@ public class TestToMarkdown
                                     "  \"files\": [],\r\n" +
                                     "  \"packages\": [" +
                                     "    {\r\n" +
-                                    "      \"SPDXID\": \"SPDXRef-Package\",\r\n" +
+                                    "      \"SPDXID\": \"SPDXRef-Package-1\",\r\n" +
                                     "      \"name\": \"Test Package\",\r\n" +
+                                    "      \"versionInfo\": \"1.0.0\",\r\n" +
+                                    "      \"downloadLocation\": \"https://github.com/demaconsulting/SpdxTool\",\r\n" +
+                                    "      \"licenseConcluded\": \"MIT\"\r\n" +
+                                    "    },\r\n" +
+                                    "    {\r\n" +
+                                    "      \"SPDXID\": \"SPDXRef-Package-2\",\r\n" +
+                                    "      \"name\": \"Test Tool\",\r\n" +
                                     "      \"versionInfo\": \"1.0.0\",\r\n" +
                                     "      \"downloadLocation\": \"https://github.com/demaconsulting/SpdxTool\",\r\n" +
                                     "      \"licenseConcluded\": \"MIT\"\r\n" +
                                     "    }\r\n" +
                                     "  ],\r\n" +
-                                    "  \"relationships\": [],\r\n" +
+                                    "  \"relationships\": [\r\n" +
+                                    "    {\r\n" +
+                                    "      \"spdxElementId\": \"SPDXRef-DOCUMENT\",\r\n" +
+                                    "      \"relatedSpdxElement\": \"SPDXRef-Package-1\",\r\n" +
+                                    "      \"relationshipType\": \"DESCRIBES\"\r\n" +
+                                    "    },\r\n" +
+                                    "    {\r\n" +
+                                    "      \"spdxElementId\": \"SPDXRef-Package-2\",\r\n" +
+                                    "      \"relatedSpdxElement\": \"SPDXRef-Package-1\",\r\n" +
+                                    "      \"relationshipType\": \"BUILD_TOOL_OF\"\r\n" +
+                                    "    }\r\n" +
+                                    "  ],\r\n" +
                                     "  \"spdxVersion\": \"SPDX-2.2\",\r\n" +
                                     "  \"dataLicense\": \"CC0-1.0\",\r\n" +
                                     "  \"SPDXID\": \"SPDXRef-DOCUMENT\",\r\n" +
@@ -59,7 +77,7 @@ public class TestToMarkdown
                                     "    \"created\": \"2021-10-01T00:00:00Z\",\r\n" +
                                     "    \"creators\": [ \"Person: Malcolm Nixon\" ]\r\n" +
                                     "  },\r\n" +
-                                    "  \"documentDescribes\": [ \"SPDXRef-Package\" ]\r\n" +
+                                    "  \"documentDescribes\": [ \"SPDXRef-Package-1\" ]\r\n" +
                                     "}";
 
         try
@@ -86,6 +104,24 @@ public class TestToMarkdown
             // Verify the contents
             Assert.IsTrue(markdown.Contains("## SPDX Document"));
             Assert.IsTrue(markdown.Contains("| File Name | test.spdx.json |"));
+            Assert.IsTrue(markdown.Contains("| Name | Test Document |"));
+            Assert.IsTrue(markdown.Contains("| File Name | test.spdx.json |"));
+
+            // Find the packages section
+            var packagesPosition = markdown.IndexOf("# Package Summary", StringComparison.Ordinal);
+            Assert.IsTrue(packagesPosition >= 0);
+
+            // Find the tools section
+            var toolsPosition = markdown.IndexOf("# Tool Summary", StringComparison.Ordinal);
+            Assert.IsTrue(toolsPosition >= 0);
+
+            // Verify "Test Package" is a package
+            var testPackagePosition = markdown.IndexOf("| Test Package | 1.0.0 | MIT |", StringComparison.Ordinal);
+            Assert.IsTrue(testPackagePosition > packagesPosition && testPackagePosition < toolsPosition);
+
+            // Verify "Test Tool" is a tool
+            var testToolPosition = markdown.IndexOf("| Test Tool | 1.0.0 | MIT |", StringComparison.Ordinal);
+            Assert.IsTrue(testToolPosition > toolsPosition);
         }
         finally
         {

--- a/test/DemaConsulting.SpdxTool.Tests/TestToMarkdown.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestToMarkdown.cs
@@ -42,16 +42,23 @@ public class TestToMarkdown
                                     "  \"files\": [],\r\n" +
                                     "  \"packages\": [" +
                                     "    {\r\n" +
-                                    "      \"SPDXID\": \"SPDXRef-Package-1\",\r\n" +
-                                    "      \"name\": \"Test Package\",\r\n" +
-                                    "      \"versionInfo\": \"1.0.0\",\r\n" +
+                                    "      \"SPDXID\": \"SPDXRef-Application\",\r\n" +
+                                    "      \"name\": \"Test Application\",\r\n" +
+                                    "      \"versionInfo\": \"1.2.3\",\r\n" +
                                     "      \"downloadLocation\": \"https://github.com/demaconsulting/SpdxTool\",\r\n" +
                                     "      \"licenseConcluded\": \"MIT\"\r\n" +
                                     "    },\r\n" +
                                     "    {\r\n" +
-                                    "      \"SPDXID\": \"SPDXRef-Package-2\",\r\n" +
+                                    "      \"SPDXID\": \"SPDXRef-Library\",\r\n" +
+                                    "      \"name\": \"Test Library\",\r\n" +
+                                    "      \"versionInfo\": \"2.3.4\",\r\n" +
+                                    "      \"downloadLocation\": \"https://github.com/demaconsulting/SpdxTool\",\r\n" +
+                                    "      \"licenseConcluded\": \"MIT\"\r\n" +
+                                    "    },\r\n" +
+                                    "    {\r\n" +
+                                    "      \"SPDXID\": \"SPDXRef-Tool\",\r\n" +
                                     "      \"name\": \"Test Tool\",\r\n" +
-                                    "      \"versionInfo\": \"1.0.0\",\r\n" +
+                                    "      \"versionInfo\": \"3.4.5\",\r\n" +
                                     "      \"downloadLocation\": \"https://github.com/demaconsulting/SpdxTool\",\r\n" +
                                     "      \"licenseConcluded\": \"MIT\"\r\n" +
                                     "    }\r\n" +
@@ -59,12 +66,17 @@ public class TestToMarkdown
                                     "  \"relationships\": [\r\n" +
                                     "    {\r\n" +
                                     "      \"spdxElementId\": \"SPDXRef-DOCUMENT\",\r\n" +
-                                    "      \"relatedSpdxElement\": \"SPDXRef-Package-1\",\r\n" +
+                                    "      \"relatedSpdxElement\": \"SPDXRef-Application\",\r\n" +
                                     "      \"relationshipType\": \"DESCRIBES\"\r\n" +
                                     "    },\r\n" +
                                     "    {\r\n" +
-                                    "      \"spdxElementId\": \"SPDXRef-Package-2\",\r\n" +
-                                    "      \"relatedSpdxElement\": \"SPDXRef-Package-1\",\r\n" +
+                                    "      \"spdxElementId\": \"SPDXRef-Application\",\r\n" +
+                                    "      \"relatedSpdxElement\": \"SPDXRef-Library\",\r\n" +
+                                    "      \"relationshipType\": \"CONTAINS\"\r\n" +
+                                    "    },\r\n" +
+                                    "    {\r\n" +
+                                    "      \"spdxElementId\": \"SPDXRef-Tool\",\r\n" +
+                                    "      \"relatedSpdxElement\": \"SPDXRef-Application\",\r\n" +
                                     "      \"relationshipType\": \"BUILD_TOOL_OF\"\r\n" +
                                     "    }\r\n" +
                                     "  ],\r\n" +
@@ -105,23 +117,30 @@ public class TestToMarkdown
             Assert.IsTrue(markdown.Contains("## SPDX Document"));
             Assert.IsTrue(markdown.Contains("| File Name | test.spdx.json |"));
             Assert.IsTrue(markdown.Contains("| Name | Test Document |"));
-            Assert.IsTrue(markdown.Contains("| File Name | test.spdx.json |"));
+
+            // Find the root packages section
+            var rootPackagesIndex = markdown.IndexOf("# Root Packages", StringComparison.Ordinal);
+            Assert.IsTrue(rootPackagesIndex >= 0);
 
             // Find the packages section
-            var packagesPosition = markdown.IndexOf("# Package Summary", StringComparison.Ordinal);
-            Assert.IsTrue(packagesPosition >= 0);
+            var packagesIndex = markdown.IndexOf("# Packages", StringComparison.Ordinal);
+            Assert.IsTrue(packagesIndex >= 0);
 
             // Find the tools section
-            var toolsPosition = markdown.IndexOf("# Tool Summary", StringComparison.Ordinal);
-            Assert.IsTrue(toolsPosition >= 0);
+            var toolsIndex = markdown.IndexOf("# Tools", StringComparison.Ordinal);
+            Assert.IsTrue(toolsIndex >= 0);
 
-            // Verify "Test Package" is a package
-            var testPackagePosition = markdown.IndexOf("| Test Package | 1.0.0 | MIT |", StringComparison.Ordinal);
-            Assert.IsTrue(testPackagePosition > packagesPosition && testPackagePosition < toolsPosition);
+            // Verify "Test Application" is a root package
+            var testPackageIndex = markdown.IndexOf("| Test Application | 1.2.3 | MIT |", StringComparison.Ordinal);
+            Assert.IsTrue(testPackageIndex > rootPackagesIndex && testPackageIndex < packagesIndex);
+
+            // Verify "Test Library" is a package
+            var testLibraryIndex = markdown.IndexOf("| Test Library | 2.3.4 | MIT |", StringComparison.Ordinal);
+            Assert.IsTrue(testLibraryIndex > packagesIndex && testLibraryIndex < toolsIndex);
 
             // Verify "Test Tool" is a tool
-            var testToolPosition = markdown.IndexOf("| Test Tool | 1.0.0 | MIT |", StringComparison.Ordinal);
-            Assert.IsTrue(testToolPosition > toolsPosition);
+            var testToolPosition = markdown.IndexOf("| Test Tool | 3.4.5 | MIT |", StringComparison.Ordinal);
+            Assert.IsTrue(testToolPosition > toolsIndex);
         }
         finally
         {


### PR DESCRIPTION
This PR implements #24 and #28 by enhancing the summary output. The following demonstrates its output on the SpdxTool unit tests project:

## SpdxTool Tests

| Item | Details |
| :--- | :-------- |
| File Name | manifest.spdx.json |
| Name | DemaConsulting.SpdxTool.Tests 0.0.0-run.63 |
| Files | 335 |
| Packages | 16 |
| Relationships | 17 |
| Created | 2024-06-05T01:01:28Z |
| Creator | Organization: DemaConsulting |
| Creator | Tool: Microsoft.SBOMTool-2.2.5 |
| Creator | Tool: DemaConsulting.SpdxTool-0.0.0-run.63 |


### Root Packages

| Name | Version | License |
| :-------- | :--- | :--- |
| DemaConsulting.SpdxTool.Tests | 0.0.0-run.63 | NOASSERTION |


### Packages

| Name | Version | License |
| :-------- | :--- | :--- |
| coverlet.collector | 6.0.2 | NOASSERTION |
| Microsoft.ApplicationInsights | 2.22.0 | NOASSERTION |
| Microsoft.CodeCoverage | 17.10.0 | NOASSERTION |
| Microsoft.NET.Test.Sdk | 17.10.0 | NOASSERTION |
| Microsoft.Testing.Extensions.Telemetry | 1.2.1 | NOASSERTION |
| Microsoft.Testing.Extensions.TrxReport.Abstractions | 1.2.1 | NOASSERTION |
| Microsoft.Testing.Extensions.VSTestBridge | 1.2.1 | NOASSERTION |
| Microsoft.Testing.Platform | 1.2.1 | NOASSERTION |
| Microsoft.Testing.Platform.MSBuild | 1.2.1 | NOASSERTION |
| Microsoft.TestPlatform.ObjectModel | 17.10.0 | NOASSERTION |
| Microsoft.TestPlatform.TestHost | 17.10.0 | NOASSERTION |
| MSTest.TestAdapter | 3.4.3 | NOASSERTION |
| MSTest.TestFramework | 3.4.3 | NOASSERTION |
| Newtonsoft.Json | 13.0.1 | NOASSERTION |


### Tools

| Name | Version | License |
| :-------- | :--- | :--- |
| DotNet SDK | 8.0.301 | MIT |


