### PR TITLE
Rename 'sha256' command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Commands:
   add-relationship <spdx.json> <args>      Add relationship between elements.
   copy-package <spdx.json> <args>          Copy package between SPDX documents (workflow only).
   find-package <spdx.json> <criteria>      Find package ID in SPDX document
+  hash <operation> <algorithm> <file>      Generate or verify hashes of files
   print <text>                             Print text to the console
   query <pattern> <program> [args]         Query program output for value
   rename-id <arguments>                    Rename an element ID in an SPDX document.
   run-workflow <workflow.yaml>             Runs the workflow file
-  sha256 <operation> <file>                Generate or verify sha256 hashes of files
   to-markdown <spdx.json> <out.md> [args]  Create Markdown summary for SPDX document
   update-package                           Update package in SPDX document (workflow only).
   validate <spdx.json> [ntia]              Validate SPDX document for issues
@@ -192,6 +192,13 @@ steps:
     filename: <filename>          # Optional package filename
     download: <url>               # Optional package download URL
 
+  # Perform hash operations on the specified file
+- command: hash
+  inputs:
+    operation: generate | verify
+    algorithm: sha256
+    file: <file>
+
   # Print text to the console
 - command: print
   inputs:
@@ -222,12 +229,6 @@ steps:
     file: other-workflow-file.yaml
     parameters:
       <optional parameters>
-
-  # Perform Sha256 operations on the specified file
-- command: sha256
-  inputs:
-    operation: generate | verify
-    file: <file>
 
   # Create a summary markdown from the specified SPDX document
 - command: to-markdown

--- a/spdx-workflow.yaml
+++ b/spdx-workflow.yaml
@@ -54,10 +54,11 @@ steps:
       comment: The DotNet SDK is used to build SpdxTool
 
   # Update the Sha256 digest on the tool SPDX document
-- command: sha256
+- command: hash
   displayName: Update SpdxTool Sha256
   inputs:
     operation: generate
+    algorithm: sha256
     file: ${{ tool-spdx }}
 
   # Validate the tool SPDX document
@@ -107,10 +108,11 @@ steps:
       comment: The DotNet SDK is used to run the SpdxTool Tests
 
   # Update the Sha256 digest on the tests SPDX document
-- command: sha256
+- command: hash
   displayName: Update SpdxTool Tests Sha256
   inputs:
     operation: generate
+    algorithm: sha256
     file: ${{ tests-spdx }}
 
   # Validate the tests SPDX document

--- a/src/DemaConsulting.SpdxTool/Commands/CommandRegistry.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/CommandRegistry.cs
@@ -15,11 +15,11 @@ public static class CommandsRegistry
         { AddRelationship.Entry.Name, AddRelationship.Entry },
         { CopyPackage.Entry.Name, CopyPackage.Entry },
         { FindPackage.Entry.Name, FindPackage.Entry },
+        { Hash.Entry.Name, Hash.Entry },
         { Print.Entry.Name, Print.Entry },
         { Query.Entry.Name, Query.Entry },
         { RenameId.Entry.Name, RenameId.Entry },
         { RunWorkflow.Entry.Name, RunWorkflow.Entry },
-        { Sha256.Entry.Name, Sha256.Entry },
         { ToMarkdown.Entry.Name, ToMarkdown.Entry },
         { UpdatePackage.Entry.Name, UpdatePackage.Entry },
         { Validate.Entry.Name, Validate.Entry }

--- a/src/DemaConsulting.SpdxTool/Commands/Hash.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/Hash.cs
@@ -4,34 +4,35 @@ using YamlDotNet.RepresentationModel;
 namespace DemaConsulting.SpdxTool.Commands;
 
 /// <summary>
-/// Sha256 command
+/// Hash command
 /// </summary>
-public class Sha256 : Command
+public class Hash : Command
 {
     /// <summary>
     /// Singleton instance of this command
     /// </summary>
-    public static readonly Sha256 Instance = new();
+    public static readonly Hash Instance = new();
 
     /// <summary>
     /// Entry information for this command
     /// </summary>
     public static readonly CommandEntry Entry = new(
-        "sha256",
-        "sha256 <operation> <file>",
-        "Generate or verify sha256 hashes of files",
+        "hash",
+        "hash <operation> <algorithm> <file>",
+        "Generate or verify hashes of files",
         new[]
         {
-            "This command generates or verifies sha256 hashes.",
+            "This command generates or verifies hashes.",
             "",
             "From the command-line this can be used as:",
-            "  spdx-tool sha256 generate <file>",
-            "  spdx-tool sha256 verify <file>",
+            "  spdx-tool hash generate sha256 <file>",
+            "  spdx-tool hash verify sha256 <file>",
             "",
             "From a YAML file this can be used as:",
-            "  - command: sha256",
+            "  - command: hash",
             "    inputs:",
             "      operation: generate | verify",
+            "      algorithm: sha256",
             "      file: <file>"
         },
         Instance);
@@ -39,19 +40,22 @@ public class Sha256 : Command
     /// <summary>
     /// Private constructor - this is a singleton
     /// </summary>
-    private Sha256()
+    private Hash()
     {
     }
 
     /// <inheritdoc />
     public override void Run(string[] args)
     {
-        // Report an error if the number of arguments is not 2
-        if (args.Length != 2)
-            throw new CommandUsageException("'sha256' command missing arguments");
+        // Report an error if the number of arguments is not 3
+        if (args.Length != 3)
+            throw new CommandUsageException("'hash' command missing arguments");
 
-        // Do the Sha256 operation
-        DoSha256Operation(args[0], args[1]);
+        // Do the hash operation
+        var operation = args[0];
+        var algorithm = args[1];
+        var file = args[2];
+        DoHashOperation(operation, algorithm, file);
     }
 
     /// <inheritdoc />
@@ -62,24 +66,34 @@ public class Sha256 : Command
 
         // Get the 'operation' input
         var operation = GetMapString(inputs, "operation", variables) ??
-                        throw new YamlException(step.Start, step.End, "'sha256' command missing 'operation' input");
+                        throw new YamlException(step.Start, step.End, "'hash' command missing 'operation' input");
+
+        // Get the 'algorithm' input
+        var algorithm = GetMapString(inputs, "algorithm", variables) ??
+                   throw new YamlException(step.Start, step.End, "'hash' command missing 'algorithm' input");
 
         // Get the 'file' input
         var file = GetMapString(inputs, "file", variables) ??
-                   throw new YamlException(step.Start, step.End, "'sha256' command missing 'file' input");
+                   throw new YamlException(step.Start, step.End, "'hash' command missing 'file' input");
 
-        // Do the Sha256 operation
-        DoSha256Operation(operation, file);
+        // Do the hash operation
+        DoHashOperation(operation, algorithm, file);
     }
 
     /// <summary>
     /// Do the requested Sha256 operation
     /// </summary>
     /// <param name="operation">Operation to perform (generate or verify)</param>
+    /// <param name="algorithm">Hash algorithm</param>
     /// <param name="file">File to perform operation on</param>
     /// <exception cref="CommandUsageException">On usage error</exception>
-    public static void DoSha256Operation(string operation, string file)
+    public static void DoHashOperation(string operation, string algorithm, string file)
     {
+        // Check the algorithm
+        if (algorithm != "sha256")
+            throw new CommandUsageException($"'hash' command invalid algorithm '{algorithm}'");
+
+        // Process the operation
         switch (operation)
         {
             case "generate":
@@ -91,7 +105,7 @@ public class Sha256 : Command
                 break;
 
             default:
-                throw new CommandUsageException($"'sha256' command invalid operation '{operation}'");
+                throw new CommandUsageException($"'hash' command invalid operation '{operation}'");
         }
     }
 

--- a/test/DemaConsulting.SpdxTool.Tests/TestHash.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestHash.cs
@@ -1,33 +1,34 @@
 ﻿namespace DemaConsulting.SpdxTool.Tests;
 
 [TestClass]
-public class TestSha256
+public class TestHash
 {
     [TestMethod]
-    public void Sha256CommandMissingArguments()
+    public void HashCommandMissingArguments()
     {
         // Run the command
         var exitCode = Runner.Run(
             out var output,
             "dotnet",
             "DemaConsulting.SpdxTool.dll",
-            "sha256");
+            "hash");
 
         // Verify error reported
         Assert.AreEqual(1, exitCode);
-        Assert.IsTrue(output.Contains("'sha256' command missing arguments"));
+        Assert.IsTrue(output.Contains("'hash' command missing arguments"));
     }
 
     [TestMethod]
-    public void Sha256CommandGenerateMissingFile()
+    public void HashCommandGenerateMissingFile()
     {
         // Run the command
         var exitCode = Runner.Run(
             out var output,
             "dotnet",
             "DemaConsulting.SpdxTool.dll",
-            "sha256",
+            "hash",
             "generate",
+            "sha256",
             "missing-file.txt");
 
         // Verify error reported
@@ -36,7 +37,7 @@ public class TestSha256
     }
 
     [TestMethod]
-    public void Sha256CommandGenerate()
+    public void HashCommandGenerate()
     {
         try
         {
@@ -47,8 +48,9 @@ public class TestSha256
                 out _,
                 "dotnet",
                 "DemaConsulting.SpdxTool.dll",
-                "sha256",
+                "hash",
                 "generate",
+                "sha256",
                 "test.txt");
 
             // Verify success reported
@@ -67,15 +69,16 @@ public class TestSha256
     }
 
     [TestMethod]
-    public void Sha256CommandVerifyMissingFile()
+    public void HashCommandVerifyMissingFile()
     {
         // Run the command
         var exitCode = Runner.Run(
             out var output,
             "dotnet",
             "DemaConsulting.SpdxTool.dll",
-            "sha256",
+            "hash",
             "verify",
+            "sha256",
             "missing-file.txt");
 
         // Verify error reported
@@ -84,7 +87,7 @@ public class TestSha256
     }
 
     [TestMethod]
-    public void Sha256CommandVerifyBad()
+    public void HashCommandVerifyBad()
     {
         try
         {
@@ -96,8 +99,9 @@ public class TestSha256
                 out var output,
                 "dotnet",
                 "DemaConsulting.SpdxTool.dll",
-                "sha256",
+                "hash",
                 "verify",
+                "sha256",
                 "test.txt");
 
             // Verify error reported
@@ -112,7 +116,7 @@ public class TestSha256
     }
 
     [TestMethod]
-    public void Sha256CommandVerifyGood()
+    public void HashCommandVerifyGood()
     {
         try
         {
@@ -124,8 +128,9 @@ public class TestSha256
                 out var output,
                 "dotnet",
                 "DemaConsulting.SpdxTool.dll",
-                "sha256",
+                "hash",
                 "verify",
+                "sha256",
                 "test.txt");
 
             // Verify success reported


### PR DESCRIPTION
This PR renames the 'sha256' command  to 'hash'. The command now requires the user to specify the hash algorithm (currently only sha256) to eventually support different algorithms.