### PR TITLE
Use default system proxy for downloading workflows.

### DIFF
--- a/src/DemaConsulting.SpdxTool/Commands/RunWorkflow.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/RunWorkflow.cs
@@ -197,8 +197,20 @@ public class RunWorkflow : Command
     /// <exception cref="CommandErrorException">on error</exception>
     public static Dictionary<string, string> RunUrl(string url, string? integrity, Dictionary<string, string> parameters)
     {
+        // Construct the client handler to use the system proxy
+        var handler = new HttpClientHandler
+        {
+            DefaultProxyCredentials = CredentialCache.DefaultCredentials,
+            Proxy = WebRequest.GetSystemWebProxy(),
+            PreAuthenticate = true
+        };
+
+        Console.WriteLine($"Handler = {handler}");
+        Console.WriteLine($"DefaultProxyCredentials = {handler.DefaultProxyCredentials}");
+        Console.WriteLine($"Proxy = {handler.Proxy}");
+
         // Construct the HTTP client
-        using var client = new HttpClient();
+        using var client = new HttpClient(handler);
 
         // Execute the Get request on the server
         var getTask = client.GetAsync(url);


### PR DESCRIPTION
This PR fixes #35 by configuring the HTTP client to use the system proxy and credentials.