### PR TITLE
Make add-package and copy-package relationships optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ steps:
       license: <license>          # Optional package license
       purl: <package-url>         # Optional package purl
       cpe23: <cpe-identifier>     # Optional package cpe23
-    relationships:                # Relationships
+    relationships:                # Optional relationships
     - type: <relationship>        # Relationship type
       element: <element>          # Related element
       comment: <comment>          # Optional comment
@@ -189,7 +189,7 @@ steps:
     to: <to.spdx.json>            # Destination SPDX file name
     package: <package>            # Package ID
     recursive: true               # Optional recursive flag
-    relationships:                # Relationships
+    relationships:                # Optional relationships
     - type: <relationship>        # Relationship type
       element: <element>          # Related element
       comment: <comment>          # Optional comment

--- a/src/DemaConsulting.SpdxTool/Commands/AddPackage.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/AddPackage.cs
@@ -44,7 +44,7 @@ public class AddPackage : Command
             "        license: <license>          # Optional package license",
             "        purl: <package-url>         # Optional package purl",
             "        cpe23: <cpe-identifier>     # Optional package cpe23",
-            "      relationships:                # Relationships",
+            "      relationships:                # Optional relationships",
             "      - type: <relationship>        # Relationship type",
             "        element: <element>          # Related element",
             "        comment: <comment>          # Optional comment",
@@ -89,8 +89,7 @@ public class AddPackage : Command
         var package = ParsePackage("add-package", packageMap, variables);
 
         // Parse the relationships
-        var relationshipsSequence = GetMapSequence(inputs, "relationships") ??
-                                    throw new YamlException(step.Start, step.End, "'add-package' missing 'relationships' input");
+        var relationshipsSequence = GetMapSequence(inputs, "relationships");
         var relationships = AddRelationship.Parse("add-package", package.Id, relationshipsSequence, variables);
 
         // Add the package

--- a/src/DemaConsulting.SpdxTool/Commands/AddRelationship.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/AddRelationship.cs
@@ -161,9 +161,13 @@ public class AddRelationship : Command
     public static SpdxRelationship[] Parse(
         string command,
         string packageId,
-        YamlSequenceNode relationships,
+        YamlSequenceNode? relationships,
         Dictionary<string, string> variables)
     {
+        // Handle no relationships
+        if (relationships == null)
+            return Array.Empty<SpdxRelationship>();
+
         // Parse each relationship
         return relationships.Children.Select(node =>
         {

--- a/src/DemaConsulting.SpdxTool/Commands/CopyPackage.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/CopyPackage.cs
@@ -36,7 +36,7 @@ public class CopyPackage : Command
             "      to: <to.spdx.json>            # Destination SPDX file name",
             "      package: <package>            # Package ID",
             "      recursive: true               # Optional recursive flag",
-            "      relationships:                # Relationships",
+            "      relationships:                # Optional relationships",
             "      - type: <relationship>        # Relationship type",
             "        element: <element>          # Related element",
             "        comment: <comment>          # Optional comment",
@@ -109,8 +109,7 @@ public class CopyPackage : Command
             throw new YamlException(step.Start, step.End, "'copy-package' invalid 'recursive' input");
 
         // Parse the relationships
-        var relationshipsSequence = GetMapSequence(inputs, "relationships") ??
-                                    throw new YamlException(step.Start, step.End, "'copy-package' missing 'relationships' input");
+        var relationshipsSequence = GetMapSequence(inputs, "relationships");
         var relationships = AddRelationship.Parse("add-package", packageId, relationshipsSequence, variables);
 
         // Copy the package


### PR DESCRIPTION
This PR fixes #34 by making the relationships input optional for the add-package and copy-package commands.