### PR TITLE
Modified add-relationship to replace existing relationships by default.

### DIFF
--- a/docs/spdx-tool-workflow-files.md
+++ b/docs/spdx-tool-workflow-files.md
@@ -124,6 +124,7 @@ steps:
   inputs:
     spdx: <spdx.json>             # SPDX file name
     id: <id>                      # Element ID
+    replace: false                # Replace existing relationships (default: true)
     relationships:
     - type: <relationship>        # Relationship type
       element: <element>          # Related element

--- a/src/DemaConsulting.SpdxTool/Commands/CopyPackage.cs
+++ b/src/DemaConsulting.SpdxTool/Commands/CopyPackage.cs
@@ -289,7 +289,7 @@ public sealed class CopyPackage : Command
             Copy(fromDoc, toDoc, childId, files);
 
             // Add/enhance the relationship
-            AddRelationship.Add(toDoc, relationship);
+            SpdxModel.Transform.SpdxRelationships.Add(toDoc, relationship);
 
             // Report copied, and process children if not already processed
             if (copied.Add(childId))

--- a/src/DemaConsulting.SpdxTool/DemaConsulting.SpdxTool.csproj
+++ b/src/DemaConsulting.SpdxTool/DemaConsulting.SpdxTool.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DemaConsulting.SpdxModel" Version="1.3.2" />
+    <PackageReference Include="DemaConsulting.SpdxModel" Version="1.4.0" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR implements #62 by allowing the add-relationship command to replace existing relationships. Optionally the user may choose not to replace existing relationships, or may add multiple relationships simultaneously.