### PR TITLE
Add multitarget support for DotNet 8, 9, and 10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "dotnet-sonarscanner": {
-      "version": "10.2.0",
+      "version": "11.0.0",
       "commands": [
         "dotnet-sonarscanner"
       ]
     },
     "microsoft.sbom.dotnettool": {
-      "version": "4.0.3",
+      "version": "4.1.4",
       "commands": [
         "sbom-tool"
       ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,16 +24,17 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup dotnet 6/8
-        uses: actions/setup-dotnet@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            6.x
             8.x
+            9.x
+            10.x
 
       - name: Restore Tools
         run: >
@@ -124,7 +125,7 @@ jobs:
           --validate
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifacts-${{ inputs.os }}
           path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,16 +40,16 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Setup dotnet 8
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.x
+            10.x
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: artifacts-ubuntu-latest
           path: artifacts

--- a/src/DemaConsulting.SpdxTool/DemaConsulting.SpdxTool.csproj
+++ b/src/DemaConsulting.SpdxTool/DemaConsulting.SpdxTool.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -52,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DemaConsulting.SpdxModel" Version="2.2.1" />
+    <PackageReference Include="DemaConsulting.SpdxModel" Version="2.3.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/test/DemaConsulting.SpdxTool.Tests/DemaConsulting.SpdxTool.Tests.csproj
+++ b/test/DemaConsulting.SpdxTool.Tests/DemaConsulting.SpdxTool.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <LangVersion>12</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -19,9 +20,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/DemaConsulting.SpdxTool.Tests/TestAddPackage.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestAddPackage.cs
@@ -125,12 +125,12 @@ public class TestAddPackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify both packages present
-            Assert.AreEqual(2, doc.Packages.Length);
+            Assert.HasCount(2, doc.Packages);
             Assert.AreEqual("SPDXRef-Package-1", doc.Packages[0].Id);
             Assert.AreEqual("SPDXRef-Package-2", doc.Packages[1].Id);
 
             // Assert: Verify the relationship
-            Assert.AreEqual(2, doc.Relationships.Length);
+            Assert.HasCount(2, doc.Relationships);
             Assert.AreEqual("SPDXRef-Package-2", doc.Relationships[1].Id);
             Assert.AreEqual(SpdxRelationshipType.BuildToolOf, doc.Relationships[1].RelationshipType);
             Assert.AreEqual("SPDXRef-Package-1", doc.Relationships[1].RelatedSpdxElement);
@@ -205,11 +205,11 @@ public class TestAddPackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify package present
-            Assert.AreEqual(1, doc.Packages.Length);
+            Assert.HasCount(1, doc.Packages);
             Assert.AreEqual("SPDXRef-Package-1", doc.Packages[0].Id);
 
             // Assert: Verify no relationships
-            Assert.AreEqual(0, doc.Relationships.Length);
+            Assert.IsEmpty(doc.Relationships);
         }
         finally
         {
@@ -304,12 +304,12 @@ public class TestAddPackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify both packages present
-            Assert.AreEqual(2, doc.Packages.Length);
+            Assert.HasCount(2, doc.Packages);
             Assert.AreEqual("SPDXRef-Package-1", doc.Packages[0].Id);
             Assert.AreEqual("SPDXRef-Package-DotNet", doc.Packages[1].Id);
 
             // Assert: Verify the relationship
-            Assert.AreEqual(2, doc.Relationships.Length);
+            Assert.HasCount(2, doc.Relationships);
             Assert.AreEqual("SPDXRef-Package-DotNet", doc.Relationships[1].Id);
             Assert.AreEqual(SpdxRelationshipType.BuildToolOf, doc.Relationships[1].RelationshipType);
             Assert.AreEqual("SPDXRef-Package-1", doc.Relationships[1].RelatedSpdxElement);

--- a/test/DemaConsulting.SpdxTool.Tests/TestAddRelationship.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestAddRelationship.cs
@@ -137,7 +137,7 @@ public class TestAddRelationship
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify the relationship added
-            Assert.AreEqual(1, doc.Relationships.Length);
+            Assert.HasCount(1, doc.Relationships);
             Assert.AreEqual("SPDXRef-Package-1", doc.Relationships[0].Id);
             Assert.AreEqual(SpdxRelationshipType.Contains, doc.Relationships[0].RelationshipType);
             Assert.AreEqual("SPDXRef-Package-2", doc.Relationships[0].RelatedSpdxElement);
@@ -191,7 +191,7 @@ public class TestAddRelationship
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify the relationship added
-            Assert.AreEqual(1, doc.Relationships.Length);
+            Assert.HasCount(1, doc.Relationships);
             Assert.AreEqual("SPDXRef-Package-1", doc.Relationships[0].Id);
             Assert.AreEqual(SpdxRelationshipType.Contains, doc.Relationships[0].RelationshipType);
             Assert.AreEqual("SPDXRef-Package-2", doc.Relationships[0].RelatedSpdxElement);
@@ -265,7 +265,7 @@ public class TestAddRelationship
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify the relationships added
-            Assert.AreEqual(2, doc.Relationships.Length);
+            Assert.HasCount(2, doc.Relationships);
             Assert.AreEqual("SPDXRef-Package-1", doc.Relationships[0].Id);
             Assert.AreEqual(SpdxRelationshipType.Contains, doc.Relationships[0].RelationshipType);
             Assert.AreEqual("SPDXRef-Package-2", doc.Relationships[0].RelatedSpdxElement);
@@ -291,7 +291,7 @@ public class TestAddRelationship
             doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify the relationship replaced
-            Assert.AreEqual(1, doc.Relationships.Length);
+            Assert.HasCount(1, doc.Relationships);
             Assert.AreEqual("SPDXRef-Package-1", doc.Relationships[0].Id);
             Assert.AreEqual(SpdxRelationshipType.BuildToolOf, doc.Relationships[0].RelationshipType);
             Assert.AreEqual("SPDXRef-Package-2", doc.Relationships[0].RelatedSpdxElement);

--- a/test/DemaConsulting.SpdxTool.Tests/TestCopyPackage.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestCopyPackage.cs
@@ -162,7 +162,7 @@ public class TestCopyPackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("to.spdx.json"));
 
             // Assert: Verify both packages present
-            Assert.AreEqual(2, doc.Packages.Length);
+            Assert.HasCount(2, doc.Packages);
             Assert.AreEqual("SPDXRef-Package-1", doc.Packages[0].Id);
             Assert.AreEqual("SPDXRef-Package-2", doc.Packages[1].Id);
         }
@@ -280,12 +280,12 @@ public class TestCopyPackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("to.spdx.json"));
 
             // Assert: Verify both packages present
-            Assert.AreEqual(2, doc.Packages.Length);
+            Assert.HasCount(2, doc.Packages);
             Assert.AreEqual("SPDXRef-Package-1", doc.Packages[0].Id);
             Assert.AreEqual("SPDXRef-Package-2", doc.Packages[1].Id);
 
             // Assert: Verify the relationship
-            Assert.AreEqual(2, doc.Relationships.Length);
+            Assert.HasCount(2, doc.Relationships);
             Assert.AreEqual("SPDXRef-Package-2", doc.Relationships[1].Id);
             Assert.AreEqual(SpdxRelationshipType.ContainedBy, doc.Relationships[1].RelationshipType);
             Assert.AreEqual("SPDXRef-Package-1", doc.Relationships[1].RelatedSpdxElement);
@@ -442,14 +442,14 @@ public class TestCopyPackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("to.spdx.json"));
 
             // Assert: Verify expected packages
-            Assert.AreEqual(4, doc.Packages.Length);
+            Assert.HasCount(4, doc.Packages);
             Assert.AreEqual("SPDXRef-MainPackage", doc.Packages[0].Id);
             Assert.AreEqual("SPDXRef-Application", doc.Packages[1].Id);
             Assert.AreEqual("SPDXRef-Library", doc.Packages[2].Id);
             Assert.AreEqual("SPDXRef-Compiler", doc.Packages[3].Id);
 
             // Assert: Verify expected relationships
-            Assert.AreEqual(4, doc.Packages.Length);
+            Assert.HasCount(4, doc.Packages);
             Assert.AreEqual("SPDXRef-DOCUMENT", doc.Relationships[0].Id);
             Assert.AreEqual(SpdxRelationshipType.Describes, doc.Relationships[0].RelationshipType);
             Assert.AreEqual("SPDXRef-MainPackage", doc.Relationships[0].RelatedSpdxElement);
@@ -598,12 +598,12 @@ public class TestCopyPackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("to.spdx.json"));
 
             // Assert: Verify expected packages
-            Assert.AreEqual(2, doc.Packages.Length);
+            Assert.HasCount(2, doc.Packages);
             Assert.AreEqual("SPDXRef-MainPackage", doc.Packages[0].Id);
             Assert.AreEqual("SPDXRef-Application", doc.Packages[1].Id);
 
             // Assert: Verify expected files
-            Assert.AreEqual(2, doc.Files.Length);
+            Assert.HasCount(2, doc.Files);
             Assert.AreEqual("SPDXRef-File1", doc.Files[0].Id);
             Assert.AreEqual("SPDXRef-File2", doc.Files[1].Id);
         }

--- a/test/DemaConsulting.SpdxTool.Tests/TestToMarkdown.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestToMarkdown.cs
@@ -148,21 +148,21 @@ public class TestToMarkdown
             var markdown = File.ReadAllText("test.md");
 
             // Assert: Verify the contents
-            Assert.IsTrue(markdown.Contains("## SPDX Document"));
-            Assert.IsTrue(markdown.Contains("| File Name | test.spdx.json |"));
-            Assert.IsTrue(markdown.Contains("| Name | Test Document |"));
+            Assert.Contains("## SPDX Document", markdown);
+            Assert.Contains("| File Name | test.spdx.json |", markdown);
+            Assert.Contains("| Name | Test Document |", markdown);
 
             // Assert: Verify the root packages section
             var rootPackagesIndex = markdown.IndexOf("# Root Packages", StringComparison.Ordinal);
-            Assert.IsTrue(rootPackagesIndex >= 0);
+            Assert.IsGreaterThanOrEqualTo(0, rootPackagesIndex);
 
             // Assert: Verify the packages section
             var packagesIndex = markdown.IndexOf("# Packages", StringComparison.Ordinal);
-            Assert.IsTrue(packagesIndex >= 0);
+            Assert.IsGreaterThanOrEqualTo(0, packagesIndex);
 
             // Assert: Verify the tools section
             var toolsIndex = markdown.IndexOf("# Tools", StringComparison.Ordinal);
-            Assert.IsTrue(toolsIndex >= 0);
+            Assert.IsGreaterThanOrEqualTo(0, toolsIndex);
 
             // Assert: Verify "Test Application" is a root package
             var testPackageIndex = markdown.IndexOf("| Test Application | 1.2.3 | MIT |", StringComparison.Ordinal);
@@ -174,7 +174,7 @@ public class TestToMarkdown
 
             // Assert: Verify "Test Tool" is a tool
             var testToolPosition = markdown.IndexOf("| Test Tool | 3.4.5 | MIT |", StringComparison.Ordinal);
-            Assert.IsTrue(testToolPosition > toolsIndex);
+            Assert.IsGreaterThan(toolsIndex, testToolPosition);
         }
         finally
         {

--- a/test/DemaConsulting.SpdxTool.Tests/TestUpdatePackage.cs
+++ b/test/DemaConsulting.SpdxTool.Tests/TestUpdatePackage.cs
@@ -128,7 +128,7 @@ public class TestUpdatePackage
             var doc = Spdx2JsonDeserializer.Deserialize(File.ReadAllText("spdx.json"));
 
             // Assert: Verify both packages present
-            Assert.AreEqual(1, doc.Packages.Length);
+            Assert.HasCount(1, doc.Packages);
             Assert.AreEqual("SPDXRef-Package-1", doc.Packages[0].Id);
             Assert.AreEqual("New package name", doc.Packages[0].Name);
             Assert.AreEqual("https://new.package.download", doc.Packages[0].DownloadLocation);


### PR DESCRIPTION
This PR multi-targets DotNet 8, 9, and 10. Additionally it updates project dependencies.
